### PR TITLE
Support Kotlin-based Android library modules

### DIFF
--- a/src/main/kotlin/net/mbonnin/one/eight/OneEightPlugin.kt
+++ b/src/main/kotlin/net/mbonnin/one/eight/OneEightPlugin.kt
@@ -19,6 +19,9 @@ class OneEightPlugin : Plugin<Project> {
         withId("org.jetbrains.kotlin.jvm") {
           project.configureKotlin()
         }
+        withId("org.jetbrains.kotlin.android") {
+          project.configureKotlin()
+        }
         withId("org.jetbrains.kotlin.multiplatform") {
           project.configureKotlin()
         }


### PR DESCRIPTION
Support modules configured with the following plugins:

```
apply plugin: 'com.android.library'
apply plugin: 'kotlin-android'
```